### PR TITLE
Update Image struct for optional alt text and improve parsing tests

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -346,7 +346,7 @@ pub struct Image {
     pub title: Option<String>,
 
     /// Alternative text.
-    pub alt: String,
+    pub alt: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Hash, Eq)]

--- a/src/html_printer/inline.rs
+++ b/src/html_printer/inline.rs
@@ -1,90 +1,79 @@
 use crate::ast::*;
-use crate::html_printer::util::{escape, tag};
+use crate::html_printer::util::{ escape, tag };
 use crate::html_printer::ToDoc;
-use pretty::{Arena, DocAllocator, DocBuilder};
+use pretty::{ Arena, DocAllocator, DocBuilder };
 
 impl<'a> ToDoc<'a> for Vec<Inline> {
-    fn to_doc(&self, state: &'a crate::html_printer::State<'a>) -> DocBuilder<'a, Arena<'a>, ()> {
-        state.arena.concat(
-            self.iter()
-                .map(|inline| inline.to_doc(state))
-                .collect::<Vec<_>>(),
-        )
-    }
+  fn to_doc(&self, state: &'a crate::html_printer::State<'a>) -> DocBuilder<'a, Arena<'a>, ()> {
+    state.arena.concat(
+      self
+        .iter()
+        .map(|inline| inline.to_doc(state))
+        .collect::<Vec<_>>()
+    )
+  }
 }
 
 impl<'a> ToDoc<'a> for Inline {
-    fn to_doc(&self, state: &'a crate::html_printer::State<'a>) -> DocBuilder<'a, Arena<'a>, ()> {
-        match self {
-            Inline::Text(t) => state.arena.text(escape(t)),
-            Inline::LineBreak => tag(state, "br", Vec::new(), state.arena.nil()),
-            Inline::Code(code) => tag(state, "code", Vec::new(), state.arena.text(escape(code))),
-            Inline::Html(html) => state.arena.text(html.clone()),
-            Inline::Emphasis(children) => tag(state, "em", Vec::new(), children.to_doc(state)),
-            Inline::Strong(children) => tag(state, "b", Vec::new(), children.to_doc(state)),
-            Inline::Strikethrough(children) => tag(state, "s", Vec::new(), children.to_doc(state)),
-            Inline::Link(Link {
-                destination,
-                title,
-                children,
-            }) => {
-                let mut attributes = vec![("href".to_owned(), escape(destination))];
-                if let Some(title) = title {
-                    attributes.push(("title".to_owned(), escape(title)))
-                }
-                tag(state, "a", attributes, children.to_doc(state))
-            }
-            Inline::Image(Image {
-                destination,
-                title,
-                alt,
-            }) => {
-                let mut attributes = vec![
-                    ("src".to_owned(), escape(destination)),
-                    ("alt".to_owned(), escape(alt)),
-                ];
-                if let Some(title) = title {
-                    attributes.push(("title".to_owned(), escape(title)))
-                }
-                tag(state, "img", attributes, state.arena.nil())
-            }
-            Inline::Autolink(link) => tag(
-                state,
-                "a",
-                vec![("href".to_owned(), escape(link))],
-                state.arena.text(escape(link)),
-            ),
-            Inline::FootnoteReference(label) => {
-                let index = match state.get_footnote_index(label) {
-                    Some(v) => v,
-                    None => return state.arena.nil(),
-                };
-                tag(
-                    state,
-                    "a",
-                    vec![
-                        ("class".to_owned(), "markdown-footnote-reference".to_owned()),
-                        (
-                            "href".to_owned(),
-                            escape(&format!("#{}{}", state.config.anchor_prefix, index)),
-                        ),
-                    ],
-                    state.arena.text(format!("[{index}]")),
-                )
-            }
-            Inline::Empty => state.arena.nil(),
-            Inline::LinkReference(v) => {
-                let definition = match state.get_link_definition(&v.label) {
-                    Some(v) => v,
-                    None => return state.arena.nil(),
-                };
-                let mut attributes =
-                    vec![("href".to_owned(), escape(definition.destination.as_str()))];
-                if let Some(title) = &definition.title {
-                    attributes.push(("title".to_owned(), escape(title)))
-                }
-                tag(state, "a", attributes, v.text.to_doc(state))
-            }
+  fn to_doc(&self, state: &'a crate::html_printer::State<'a>) -> DocBuilder<'a, Arena<'a>, ()> {
+    match self {
+      Inline::Text(t) => state.arena.text(escape(t)),
+      Inline::LineBreak => tag(state, "br", Vec::new(), state.arena.nil()),
+      Inline::Code(code) => tag(state, "code", Vec::new(), state.arena.text(escape(code))),
+      Inline::Html(html) => state.arena.text(html.clone()),
+      Inline::Emphasis(children) => tag(state, "em", Vec::new(), children.to_doc(state)),
+      Inline::Strong(children) => tag(state, "b", Vec::new(), children.to_doc(state)),
+      Inline::Strikethrough(children) => tag(state, "s", Vec::new(), children.to_doc(state)),
+      Inline::Link(Link { destination, title, children }) => {
+        let mut attributes = vec![("href".to_owned(), escape(destination))];
+        if let Some(title) = title {
+          attributes.push(("title".to_owned(), escape(title)));
         }
+        tag(state, "a", attributes, children.to_doc(state))
+      }
+      Inline::Image(Image { destination, title, alt }) => {
+        let mut attributes = vec![("src".to_owned(), escape(destination))];
+        if let Some(alt) = alt {
+          attributes.push(("alt".to_owned(), escape(alt)));
+        }
+        if let Some(title) = title {
+          attributes.push(("title".to_owned(), escape(title)));
+        }
+        tag(state, "img", attributes, state.arena.nil())
+      }
+      Inline::Autolink(link) =>
+        tag(state, "a", vec![("href".to_owned(), escape(link))], state.arena.text(escape(link))),
+      Inline::FootnoteReference(label) => {
+        let index = match state.get_footnote_index(label) {
+          Some(v) => v,
+          None => {
+            return state.arena.nil();
+          }
+        };
+        tag(
+          state,
+          "a",
+          vec![
+            ("class".to_owned(), "markdown-footnote-reference".to_owned()),
+            ("href".to_owned(), escape(&format!("#{}{}", state.config.anchor_prefix, index)))
+          ],
+          state.arena.text(format!("[{index}]"))
+        )
+      }
+      Inline::Empty => state.arena.nil(),
+      Inline::LinkReference(v) => {
+        let definition = match state.get_link_definition(&v.label) {
+          Some(v) => v,
+          None => {
+            return state.arena.nil();
+          }
+        };
+        let mut attributes = vec![("href".to_owned(), escape(definition.destination.as_str()))];
+        if let Some(title) = &definition.title {
+          attributes.push(("title".to_owned(), escape(title)));
+        }
+        tag(state, "a", attributes, v.text.to_doc(state))
+      }
     }
+  }
 }

--- a/src/parser/inline/image.rs
+++ b/src/parser/inline/image.rs
@@ -1,46 +1,54 @@
 use crate::parser::link_util::link_title;
 use crate::parser::MarkdownParserState;
-use crate::{
-    ast::{Image, Inline},
-    parser::link_util::link_destination,
-};
+use crate::{ ast::{ Image, Inline }, parser::link_util::link_destination };
 use nom::{
-    bytes::complete::take_while1,
-    character::complete::{char, multispace0},
-    combinator::opt,
-    sequence::{delimited, preceded},
-    IResult, Parser,
+  bytes::complete::take_while,
+  character::complete::{ char, multispace0 },
+  combinator::opt,
+  sequence::{ delimited, preceded },
+  IResult,
+  Parser,
 };
 use std::rc::Rc;
 
 // ![alt text](/url "title")
 pub(crate) fn image<'a>(
-    _state: Rc<MarkdownParserState>,
+  _state: Rc<MarkdownParserState>
 ) -> impl FnMut(&'a str) -> IResult<&'a str, Inline> {
-    move |input: &'a str| {
-        let (input, alt) = preceded(
-            char('!'),
-            delimited(char('['), take_while1(|c| c != ']'), char(']')),
-        )
-        .parse(input)?;
+  move |input: &'a str| {
+    let (input, alt) = preceded(
+      char('!'),
+      delimited(
+        char('['),
+        take_while(|c| c != ']'),
+        char(']')
+      )
+    ).parse(input)?;
 
-        let (input, (destination, title)) = delimited(
-            char('('),
-            (
-                preceded(multispace0, link_destination),
-                opt(preceded(multispace0, link_title)),
-            ),
-            preceded(multispace0, char(')')),
-        )
-        .parse(input)?;
+    let (input, (destination, title)) = delimited(
+      char('('),
+      (preceded(multispace0, link_destination), opt(preceded(multispace0, link_title))),
+      preceded(multispace0, char(')'))
+    ).parse(input)?;
 
-        Ok((
-            input,
-            Inline::Image(Image {
-                destination,
-                title,
-                alt: alt.to_owned(),
-            }),
-        ))
+    if alt.is_empty() {
+      Ok((
+        input,
+        Inline::Image(Image {
+          destination,
+          title,
+          alt: None,
+        }),
+      ))
+    } else {
+      Ok((
+        input,
+        Inline::Image(Image {
+          destination,
+          title,
+          alt: Some(alt.to_owned()),
+        }),
+      ))
     }
+  }
 }

--- a/src/parser/inline/tests/image.rs
+++ b/src/parser/inline/tests/image.rs
@@ -1,47 +1,108 @@
 use crate::ast::*;
-use crate::parser::{parse_markdown, MarkdownParserState};
+use crate::parser::{ parse_markdown, MarkdownParserState };
 
 #[test]
 fn image1() {
-    let doc = parse_markdown(MarkdownParserState::default(), "![foo](/url \"title\")").unwrap();
-    assert_eq!(
-        doc,
-        Document {
-            blocks: vec![Block::Paragraph(vec![Inline::Image(Image {
-                destination: "/url".to_owned(),
-                title: Some("title".to_owned()),
-                alt: "foo".to_owned(),
-            })])]
-        }
-    );
+  let doc = parse_markdown(MarkdownParserState::default(), "![foo](/url \"title\")").unwrap();
+  assert_eq!(doc, Document {
+    blocks: vec![
+      Block::Paragraph(
+        vec![
+          Inline::Image(Image {
+            destination: "/url".to_owned(),
+            title: Some("title".to_owned()),
+            alt: Some("foo".to_owned()),
+          })
+        ]
+      )
+    ],
+  });
 }
 
 #[test]
 fn image2() {
-    let doc = parse_markdown(MarkdownParserState::default(), "![foo](train.jpg)").unwrap();
-    assert_eq!(
-        doc,
-        Document {
-            blocks: vec![Block::Paragraph(vec![Inline::Image(Image {
-                destination: "train.jpg".to_owned(),
-                title: None,
-                alt: "foo".to_owned(),
-            })])]
-        }
-    );
+  let doc = parse_markdown(MarkdownParserState::default(), "![foo](train.jpg)").unwrap();
+  assert_eq!(doc, Document {
+    blocks: vec![
+      Block::Paragraph(
+        vec![
+          Inline::Image(Image {
+            destination: "train.jpg".to_owned(),
+            title: None,
+            alt: Some("foo".to_owned()),
+          })
+        ]
+      )
+    ],
+  });
 }
 
 #[test]
 fn image3() {
-    let doc = parse_markdown(MarkdownParserState::default(), "![foo](<url>)").unwrap();
-    assert_eq!(
-        doc,
-        Document {
-            blocks: vec![Block::Paragraph(vec![Inline::Image(Image {
-                destination: "url".to_owned(),
-                title: None,
-                alt: "foo".to_owned(),
-            })])]
-        }
-    );
+  let doc = parse_markdown(MarkdownParserState::default(), "![foo](<url>)").unwrap();
+  assert_eq!(doc, Document {
+    blocks: vec![
+      Block::Paragraph(
+        vec![
+          Inline::Image(Image {
+            destination: "url".to_owned(),
+            title: None,
+            alt: Some("foo".to_owned()),
+          })
+        ]
+      )
+    ],
+  });
+}
+#[test]
+fn no_alt_image1() {
+  let doc = parse_markdown(MarkdownParserState::default(), "![](/url \"title\")").unwrap();
+  assert_eq!(doc, Document {
+    blocks: vec![
+      Block::Paragraph(
+        vec![
+          Inline::Image(Image {
+            destination: "/url".to_owned(),
+            title: Some("title".to_owned()),
+            alt: None,
+          })
+        ]
+      )
+    ],
+  });
+}
+
+#[test]
+fn no_alt_image2() {
+  let doc = parse_markdown(MarkdownParserState::default(), "![](image.jpg)").unwrap();
+  assert_eq!(doc, Document {
+    blocks: vec![
+      Block::Paragraph(
+        vec![
+          Inline::Image(Image {
+            destination: "image.jpg".to_owned(),
+            title: None,
+            alt: None,
+          })
+        ]
+      )
+    ],
+  });
+}
+#[test]
+fn no_alt_image3() {
+  let doc = parse_markdown(MarkdownParserState::default(), "![](<url>)").unwrap();
+  assert_eq!(doc, Document {
+    blocks: vec![
+      Block::Paragraph(
+        vec![
+          Inline::Image(Image {
+            destination: "url".to_owned(),
+            title: None,
+            alt: None,
+          })
+        ]
+      )
+    ],
+  });
 }

--- a/src/printer/inline.rs
+++ b/src/printer/inline.rs
@@ -1,144 +1,132 @@
 use crate::ast::*;
-use pretty::{Arena, DocAllocator, DocBuilder};
+use pretty::{ Arena, DocAllocator, DocBuilder };
 
 pub(crate) trait ToDocInline<'a> {
-    fn to_doc_inline(
-        &self,
-        allow_newlines: bool,
-        arena: &'a Arena<'a>,
-    ) -> DocBuilder<'a, Arena<'a>, ()>;
+  fn to_doc_inline(
+    &self,
+    allow_newlines: bool,
+    arena: &'a Arena<'a>
+  ) -> DocBuilder<'a, Arena<'a>, ()>;
 }
 
 impl<'a> ToDocInline<'a> for Vec<Inline> {
-    fn to_doc_inline(
-        &self,
-        allow_newlines: bool,
-        arena: &'a Arena<'a>,
-    ) -> DocBuilder<'a, Arena<'a>, ()> {
-        arena.concat(
-            self.iter()
-                .map(|inline| inline.to_doc_inline(allow_newlines, arena))
-                .collect::<Vec<_>>(),
-        )
-    }
+  fn to_doc_inline(
+    &self,
+    allow_newlines: bool,
+    arena: &'a Arena<'a>
+  ) -> DocBuilder<'a, Arena<'a>, ()> {
+    arena.concat(
+      self
+        .iter()
+        .map(|inline| inline.to_doc_inline(allow_newlines, arena))
+        .collect::<Vec<_>>()
+    )
+  }
 }
 
 impl<'a> ToDocInline<'a> for Inline {
-    fn to_doc_inline(
-        &self,
-        allow_newlines: bool,
-        arena: &'a Arena<'a>,
-    ) -> DocBuilder<'a, Arena<'a>, ()> {
-        match self {
-            Inline::Text(t) => {
-                let words_or_spaces: Vec<_> = split_with_spaces(t);
-                let separator = if allow_newlines {
-                    arena.softline()
-                } else {
-                    arena.space()
-                };
-                let words_or_spaces = words_or_spaces.into_iter().map(|v| match v {
-                    Some(v) => arena.text(v.to_string()),
-                    None => separator.clone(),
-                });
-                arena.concat(words_or_spaces)
-            }
-            // TODO parametrize format
-            Inline::LineBreak => arena.text("  \n"),
-            Inline::Code(code) => arena.text("`").append(code.clone()).append(arena.text("`")),
-            Inline::Html(html) => arena.text(html.clone()),
-            Inline::Emphasis(children) => arena
-                .text("*")
-                .append(children.to_doc_inline(allow_newlines, arena))
-                .append(arena.text("*")),
-            Inline::Strong(children) => arena
-                .text("**")
-                .append(children.to_doc_inline(allow_newlines, arena))
-                .append(arena.text("**")),
-            Inline::Strikethrough(children) => arena
-                .text("~~")
-                .append(children.to_doc_inline(allow_newlines, arena))
-                .append(arena.text("~~")),
-            Inline::Link(Link {
-                destination,
-                title,
-                children,
-            }) => {
-                let title = match title {
-                    Some(v) => arena
-                        .text(" \"")
-                        .append(arena.text(v.clone()))
-                        .append(arena.text("\"")),
-                    None => arena.nil(),
-                };
-                arena
-                    .text("[")
-                    .append(children.to_doc_inline(allow_newlines, arena))
-                    .append(arena.text("]("))
-                    .append(arena.text(destination.clone()))
-                    .append(title)
-                    .append(")")
-            }
-            Inline::Image(Image {
-                destination,
-                title,
-                alt,
-            }) => {
-                let title_part = title
-                    .as_ref()
-                    .map(|t| format!(" \"{t}\""))
-                    .unwrap_or_default();
-                arena
-                    .text("![")
-                    .append(arena.text(alt.clone()))
-                    .append("](")
-                    .append(arena.text(destination.clone()))
-                    .append(arena.text(title_part))
-                    .append(arena.text(")"))
-            }
-            Inline::Autolink(link) => arena.text(format!("<{link}>")),
-            Inline::FootnoteReference(label) => arena.text(format!("[^{label}]")),
-            Inline::Empty => arena.nil(),
-            Inline::LinkReference(v) => {
-                if v.label == v.text {
-                    return arena
-                        .text("[")
-                        .append(v.label.to_doc_inline(allow_newlines, arena))
-                        .append("]");
-                }
-                arena
-                    .text("[")
-                    .append(v.text.to_doc_inline(allow_newlines, arena))
-                    .append("][")
-                    .append(v.label.to_doc_inline(allow_newlines, arena))
-                    .append(arena.text("]"))
-            }
+  fn to_doc_inline(
+    &self,
+    allow_newlines: bool,
+    arena: &'a Arena<'a>
+  ) -> DocBuilder<'a, Arena<'a>, ()> {
+    match self {
+      Inline::Text(t) => {
+        let words_or_spaces: Vec<_> = split_with_spaces(t);
+        let separator = if allow_newlines { arena.softline() } else { arena.space() };
+        let words_or_spaces = words_or_spaces.into_iter().map(|v| {
+          match v {
+            Some(v) => arena.text(v.to_string()),
+            None => separator.clone(),
+          }
+        });
+        arena.concat(words_or_spaces)
+      }
+      // TODO parametrize format
+      Inline::LineBreak => arena.text("  \n"),
+      Inline::Code(code) => arena.text("`").append(code.clone()).append(arena.text("`")),
+      Inline::Html(html) => arena.text(html.clone()),
+      Inline::Emphasis(children) =>
+        arena
+          .text("*")
+          .append(children.to_doc_inline(allow_newlines, arena))
+          .append(arena.text("*")),
+      Inline::Strong(children) =>
+        arena
+          .text("**")
+          .append(children.to_doc_inline(allow_newlines, arena))
+          .append(arena.text("**")),
+      Inline::Strikethrough(children) =>
+        arena
+          .text("~~")
+          .append(children.to_doc_inline(allow_newlines, arena))
+          .append(arena.text("~~")),
+      Inline::Link(Link { destination, title, children }) => {
+        let title = match title {
+          Some(v) => arena.text(" \"").append(arena.text(v.clone())).append(arena.text("\"")),
+          None => arena.nil(),
+        };
+        arena
+          .text("[")
+          .append(children.to_doc_inline(allow_newlines, arena))
+          .append(arena.text("]("))
+          .append(arena.text(destination.clone()))
+          .append(title)
+          .append(")")
+      }
+      Inline::Image(Image { destination, title, alt }) => {
+        let title_part = title
+          .as_ref()
+          .map(|t| format!(" \"{t}\""))
+          .unwrap_or_default();
+        arena
+          .text("![")
+          .append(arena.text(alt.clone().unwrap_or("".to_owned())))
+          .append("](")
+          .append(arena.text(destination.clone()))
+          .append(arena.text(title_part))
+          .append(arena.text(")"))
+      }
+      Inline::Autolink(link) => arena.text(format!("<{link}>")),
+      Inline::FootnoteReference(label) => arena.text(format!("[^{label}]")),
+      Inline::Empty => arena.nil(),
+      Inline::LinkReference(v) => {
+        if v.label == v.text {
+          return arena.text("[").append(v.label.to_doc_inline(allow_newlines, arena)).append("]");
         }
+        arena
+          .text("[")
+          .append(v.text.to_doc_inline(allow_newlines, arena))
+          .append("][")
+          .append(v.label.to_doc_inline(allow_newlines, arena))
+          .append(arena.text("]"))
+      }
     }
+  }
 }
 
 /// Split string by spaces, but keep the spaces in the result.
 fn split_with_spaces(s: &str) -> Vec<Option<&str>> {
-    let mut result = Vec::new();
-    let mut word_start: Option<usize> = None;
+  let mut result = Vec::new();
+  let mut word_start: Option<usize> = None;
 
-    for (i, c) in s.char_indices() {
-        if c.is_whitespace() {
-            if let Some(start) = word_start {
-                result.push(Some(&s[start..i]));
-                word_start = None;
-            }
-            if result.last().is_none_or(|x| x.is_some()) {
-                result.push(None);
-            }
-        } else if word_start.is_none() {
-            word_start = Some(i);
-        }
+  for (i, c) in s.char_indices() {
+    if c.is_whitespace() {
+      if let Some(start) = word_start {
+        result.push(Some(&s[start..i]));
+        word_start = None;
+      }
+      if result.last().is_none_or(|x| x.is_some()) {
+        result.push(None);
+      }
+    } else if word_start.is_none() {
+      word_start = Some(i);
     }
+  }
 
-    if let Some(start) = word_start {
-        result.push(Some(&s[start..]));
-    }
+  if let Some(start) = word_start {
+    result.push(Some(&s[start..]));
+  }
 
-    result
+  result
 }

--- a/src/printer/tests/mod.rs
+++ b/src/printer/tests/mod.rs
@@ -3,23 +3,22 @@ use rstest::rstest;
 
 mod list;
 
-#[rstest(input,
-         case("---"),
-        case(
-        r#"word1 word2"#),
-        case(
-        r#"paragraph1
+#[rstest(
+  input,
+  case("---"),
+  case(r#"word1 word2"#),
+  case(r#"paragraph1
 
 paragraph2"#),
-        case(
-        r#"# heading1
+  case(r#"# heading1
 
 ## heading2
 
 heading 3
 =========="#),
-        // case( "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."),
-         case(r#" 100. item1 paragraph1
+  // case( "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."),
+  case(
+    r#" 100. item1 paragraph1
       
       item1 paragraph2
  101. item2 paragraph1
@@ -29,155 +28,141 @@ heading 3
       item2 paragraph3
  102. item3 paragraph1
       
-      item3 paragraph2"#),
-        case(
-        r#" 1. item 1
+      item3 paragraph2"#
+  ),
+  case(r#" 1. item 1
     
      * nested list item 1
      * nested list item 2
  2. item 2"#),
-        case(
-        r#"> line1 line1 line1 line1 line1 line1 line1 line1 line1 line1 line1 line1 line1
-> line1 line1 line1 line1 line1 line1 line1 line1"#),
-        case(
-        r#"> line1 line1 line1 line1 line1 line1 line1 line1 line1 line1 line1 line1
+  case(
+    r#"> line1 line1 line1 line1 line1 line1 line1 line1 line1 line1 line1 line1 line1
+> line1 line1 line1 line1 line1 line1 line1 line1"#
+  ),
+  case(
+    r#"> line1 line1 line1 line1 line1 line1 line1 line1 line1 line1 line1 line1
 > 
-> > line1 line1 line1 line1 line1 line1 line1 line1 line1"#),
-        case(
-        r#"Это *курсив, но внутри **жирный и *обратно курсив*** снова жирный* конец."#),
-        case(
-        r#"Это \*не курсив\*, а просто звёздочки."#),
-        case(
-        r#"Вот [ссылка *с курсивом внутри*](https://example.com) и ещё текст."#),
-        case(
-        r#"Инлайн код `внутри *курсива*` не должен парситься как курсив."#),
-        case(
-        r#"Параграф первый с **жирным** текстом.
+> > line1 line1 line1 line1 line1 line1 line1 line1 line1"#
+  ),
+  case(r#"Это *курсив, но внутри **жирный и *обратно курсив*** снова жирный* конец."#),
+  case(r#"Это \*не курсив\*, а просто звёздочки."#),
+  case(r#"Вот [ссылка *с курсивом внутри*](https://example.com) и ещё текст."#),
+  case(r#"Инлайн код `внутри *курсива*` не должен парситься как курсив."#),
+  case(
+    r#"Параграф первый с **жирным** текстом.
 
 Параграф второй с *курсивом* и списком:
 
  - Первый пункт **жирный**
  - Второй пункт *курсивный*
 
-Конец."#),
-        case(
-            r#"Список с задачами:
+Конец."#
+  ),
+  case(r#"Список с задачами:
 
  - Первый пункт
  - [ ] Второй пункт
  - [X] Третий пункт
 
 Конец."#),
-        case(
-        r#"> Список внутри цитаты:
+  case(
+    r#"> Список внутри цитаты:
 
 >  - Пункт *первый*
 >  - Пункт **второй**
 >    
 >     - Подпункт `третий`
 > 
-> Конец цитаты."#),
-        case(
-        r#"## Это *курсивный* заголовок с [ссылкой](https://example.com)"#),
-        case(
-        r#"Это просто текст** а потом *ещё* звёздочки."#),
-        case(
-        r#"[ссылка с `кодом` внутри](https://example.com)"#),
-        case(
-        r#"Здесь *курсив без конца и **жирный без конца"#),
-        case(
-        "**Всё жирное и *курсивное и `кодовое внутри курсивного` и снова курсивное* снова\nжирное**"),
-        case(
-        r#"[Ссылка с \*экранированной звездочкой\* внутри](https://example.com)"#),
-        case(
-        r#"Текст с сноской[^1].
+> Конец цитаты."#
+  ),
+  case(r#"## Это *курсивный* заголовок с [ссылкой](https://example.com)"#),
+  case(r#"Это просто текст** а потом *ещё* звёздочки."#),
+  case(r#"[ссылка с `кодом` внутри](https://example.com)"#),
+  case(r#"Здесь *курсив без конца и **жирный без конца"#),
+  case(
+    "**Всё жирное и *курсивное и `кодовое внутри курсивного` и снова курсивное* снова\nжирное**"
+  ),
+  case(r#"[Ссылка с \*экранированной звездочкой\* внутри](https://example.com)"#),
+  case(r#"Текст с сноской[^1].
 
 [^1]: Это текст сноски."#),
-        case(
-        r#"Это *курсивный текст со сноской[^note]*.
+  case(r#"Это *курсивный текст со сноской[^note]*.
 
 [^note]: Сноска для курсивного текста."#),
-        case(
-        r#"[Ссылка с сноской[^linknote]](https://example.com)
+  case(r#"[Ссылка с сноской[^linknote]](https://example.com)
 
 [^linknote]: Сноска для ссылки."#),
-        case(
-        r#"# Заголовок со сноской[^headnote]
+  case(r#"# Заголовок со сноской[^headnote]
 
 [^headnote]: Пояснение к заголовку."#),
-        case(
-        r#"| Заголовок 1 | Заголовок 2 | Заголовок 3 |
+  case(
+    r#"| Заголовок 1 | Заголовок 2 | Заголовок 3 |
 | ----------- | ----------: | :---------: |
 | Ячейка 1    |    Ячейка 2 |  Ячейка 3   |
-| Ячейка 4    |    Ячейка 5 |  Ячейка 6   |"#),
-        case(
-        r#"| **Заголовок 1** | Заголовок 2 | Заголовок 3 |
+| Ячейка 4    |    Ячейка 5 |  Ячейка 6   |"#
+  ),
+  case(
+    r#"| **Заголовок 1** | Заголовок 2 | Заголовок 3 |
 | --------------- | ----------: | :---------: |
 | Ячейка 1        |    Ячейка 2 |  Ячейка 3   |
-| Ячейка 4        |    Ячейка 5 |  Ячейка 6   |"#),
-        case(
-        r#"> | Заголовок 1 | Заголовок 2 | Заголовок 3 |
+| Ячейка 4        |    Ячейка 5 |  Ячейка 6   |"#
+  ),
+  case(
+    r#"> | Заголовок 1 | Заголовок 2 | Заголовок 3 |
 > | ----------- | ----------: | :---------: |
 > | Ячейка 1    |    Ячейка 2 |  Ячейка 3   |
-> | Ячейка 4    |    Ячейка 5 |  Ячейка 6   |"#),
-        case(
-            r#"> blockquote level 1
+> | Ячейка 4    |    Ячейка 5 |  Ячейка 6   |"#
+  ),
+  case(r#"> blockquote level 1
 > 
 > > blockquote level 2"#),
-        case(
-            r#"text
+  case(r#"text
 
 ```rust
 let s = "hello\n";
 
 ```"#),
 
-        case(
-            r#"Autolinks test: <http://example.com> and <johnlepikhin@gmail.com>"#),
+  case(r#"Autolinks test: <http://example.com> and <johnlepikhin@gmail.com>"#),
 
-        // GitHub Alert tests
-        case(
-            r#"> [!NOTE]
+  // GitHub Alert tests
+  case(r#"> [!NOTE]
 > This is a note"#),
 
-        case(
-            r#"> [!TIP]
+  case(r#"> [!TIP]
 > Here's a helpful tip with **bold** and *italic* text"#),
 
-        case(
-            r#"> [!IMPORTANT]
+  case(r#"> [!IMPORTANT]
 > This is important information
 > 
 > With multiple paragraphs"#),
 
-        case(
-            r#"> [!WARNING]
+  case(r#"> [!WARNING]
 > Warning with a list:
 > 
 >  - First item
 >  - Second item
 >  - Third item"#),
 
-        case(
-            r#"> [!CAUTION]
+  case(r#"> [!CAUTION]
 > Caution alert with `inline code` and [a link](https://example.com)"#),
 
-        // Edge case: Empty alert
-        case(
-            r#"> [!NOTE]"#),
+  // Edge case: Empty alert
+  case(r#"> [!NOTE]"#),
 
-        // Edge case: Alert with nested blockquote
-        case(
-            r#"> [!TIP]
+  // Edge case: Alert with nested blockquote
+  case(
+    r#"> [!TIP]
 > This contains a nested quote:
 > 
 > > Nested quote inside alert
 > > 
-> > Second line of nested quote"#),
+> > Second line of nested quote"#
+  ),
 
-        // Edge case: Alert with code block
-        case(
-            r#"> [!WARNING]
+  // Edge case: Alert with code block
+  case(
+    r#"> [!WARNING]
 > Here's some code:
 > 
 > ```python
@@ -185,87 +170,81 @@ let s = "hello\n";
 >     print("Hello, world!")
 > ```
 > 
-> Be careful!"#),
+> Be careful!"#
+  ),
 
-        // Edge case: Multiple alerts in sequence
-        case(
-            r#"> [!NOTE]
+  // Edge case: Multiple alerts in sequence
+  case(r#"> [!NOTE]
 > First alert
 
 > [!TIP]
 > Second alert"#),
 
-        // Edge case: Alert with table
-        case(
-            r#"> [!IMPORTANT]
+  // Edge case: Alert with table
+  case(
+    r#"> [!IMPORTANT]
 > Here's a table:
 > 
 > | Column 1 | Column 2 |
 > | -------- | -------- |
-> | Cell 1   | Cell 2   |"#),
+> | Cell 1   | Cell 2   |"#
+  ),
 
-        // Edge case: Alert with footnote
-        case(
-            r#"> [!CAUTION]
+  // Edge case: Alert with footnote
+  case(r#"> [!CAUTION]
 > Text with footnote[^1]
 
 [^1]: This is the footnote"#),
 
-        // Edge case: Alert with task list
-        // Note: Current printer uses [X] for completed tasks - this is expected behavior
-        case(
-            r#"> [!TIP]
+  // Edge case: Alert with task list
+  // Note: Current printer uses [X] for completed tasks - this is expected behavior
+  case(
+    r#"> [!TIP]
 > Task list:
 > 
 >  - [X] Completed task
 >  - [ ] Incomplete task
->  - [ ] Another task"#),
+>  - [ ] Another task"#
+  ),
 
-        // Edge case: Alert with horizontal rule
-        case(
-            r#"> [!NOTE]
+  // Edge case: Alert with horizontal rule
+  case(r#"> [!NOTE]
 > Before rule
 > 
 > ---
 > 
 > After rule"#),
 
-        // Edge case: Alert with escaped content
-        case(
-            r#"> [!WARNING]
+  // Edge case: Alert with escaped content
+  case(r#"> [!WARNING]
 > This has \*escaped\* content and \[brackets\]"#),
 
-        // Edge case: Alert with HTML entity
-        // Note: Parser converts &copy; to © symbol
-        case(
-            r#"> [!IMPORTANT]
+  // Edge case: Alert with HTML entity
+  // Note: Parser converts &copy; to © symbol
+  case(r#"> [!IMPORTANT]
 > Copyright © 2024"#),
 
-        // Edge case: Alert with autolink
-        case(
-            r#"> [!CAUTION]
+  // Edge case: Alert with autolink
+  case(r#"> [!CAUTION]
 > Visit <https://example.com> for more info"#),
 
-        // Edge case: Alert with strikethrough
-        case(
-            r#"> [!TIP]
+  // Edge case: Alert with strikethrough
+  case(r#"> [!TIP]
 > This is ~~deprecated~~ text"#),
 
-        // Edge case: Alert with image
-        case(
-            r#"> [!NOTE]
+  // Edge case: Alert with image
+  case(r#"> [!NOTE]
 > ![Alt text](image.png "Image title")"#),
 
-        // Edge case: Alert with reference link
-        case(
-            r#"> [!WARNING]
+  // Edge case: Alert with reference link
+  case(r#"> [!WARNING]
 > See [this link][ref] for details
 
 [ref]: https://example.com"#),
 
-        // Edge case: Alert with complex mixed content
-        case(
-            r#"> [!IMPORTANT]
+  // Edge case: Alert with complex mixed content
+  case(
+    r#"> [!IMPORTANT]
 > # Heading inside alert
 > 
 > This has **bold**, *italic*, `code`, and ~~strikethrough~~.
@@ -277,14 +256,18 @@ let s = "hello\n";
 > console.log("code block");
 > ```
 > 
-> End of alert"#),
+> End of alert"#
+  ),
 
+  case(r#"![](image.png)"#),
+  case(r#"![alt](image.png)"#)
 )]
 fn symmetric_round_trip(input: &str) {
-    let config = crate::printer::config::Config::default();
-    let doc = crate::parser::parse_markdown(crate::parser::MarkdownParserState::default(), input)
-        .unwrap();
-    println!("{:?} => {:#?}", input, doc);
-    let result = crate::printer::render_markdown(&doc, config);
-    assert_eq!(input, result);
+  let config = crate::printer::config::Config::default();
+  let doc = crate::parser
+    ::parse_markdown(crate::parser::MarkdownParserState::default(), input)
+    .unwrap();
+  println!("{:?} => {:#?}", input, doc);
+  let result = crate::printer::render_markdown(&doc, config);
+  assert_eq!(input, result);
 }


### PR DESCRIPTION
close #7
Modify the Image struct to allow optional alternative text and enhance image parsing tests to cover cases with and without alt text. This change improves flexibility in handling images in markdown.